### PR TITLE
Replace icon dropdown with custom image upload

### DIFF
--- a/api/github_stats.py
+++ b/api/github_stats.py
@@ -123,6 +123,7 @@ def generate_custom_badge(
     compact: bool = False,
     size: str = "md",
     scale: float = 1.0,
+    icon_data: str | None = None,
 ):
     profile = STYLE_MAP.get(style, STYLE_MAP["flat"])
     palette = _resolve_theme(theme)
@@ -130,8 +131,13 @@ def generate_custom_badge(
     active_uppercase = profile.uppercase or uppercase
     label_text = (label or "label")[:40]
     value_text = (value or "value")[:52]
-    symbol = ICON_SET.get(icon, "")
-    full_label_text = f"{symbol} {label_text}".strip() if symbol else label_text
+    has_custom_icon = bool(icon_data and icon_data.startswith("data:image/"))
+    if has_custom_icon:
+        symbol = ""
+        full_label_text = label_text
+    else:
+        symbol = ICON_SET.get(icon, "")
+        full_label_text = f"{symbol} {label_text}".strip() if symbol else label_text
 
     bg_left = _safe_color(label_bg, palette["label_bg"])
     bg_right = _safe_color(value_bg, palette["value_bg"])
@@ -155,7 +161,11 @@ def generate_custom_badge(
     font_size = max(9, int(round(base_font * factor)))
     radius = min(int(round(base_radius * factor)), max(0, int(height / 2)))
 
-    left_width = _text_width(full_label_text, font_size, active_uppercase) + 2 * pad_x
+    icon_size = int(round(height * 0.65)) if has_custom_icon else 0
+    icon_pad = int(round(icon_size * 0.4)) if has_custom_icon else 0
+    icon_total_space = (icon_size + icon_pad) if has_custom_icon else 0
+
+    left_width = _text_width(full_label_text, font_size, active_uppercase) + 2 * pad_x + icon_total_space
     right_width = _text_width(value_text, font_size, active_uppercase) + 2 * pad_x
     total_width = left_width + right_width
 
@@ -177,13 +187,21 @@ def generate_custom_badge(
 </linearGradient></defs>"""
         overlay = f'<rect x="0" y="0" width="{total_width}" height="{height}" fill="url(#g)" rx="{radius}" ry="{radius}" />'
 
-    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{total_width}" height="{height}" role="img" aria-label="{_esc(label_render)}: {_esc(value_render)}">
+    icon_svg = ""
+    label_text_x = left_width / 2
+    if has_custom_icon:
+        icon_x = pad_x
+        icon_y = (height - icon_size) / 2
+        icon_svg = f'<image x="{icon_x}" y="{icon_y}" width="{icon_size}" height="{icon_size}" href="{icon_data}" />'
+        label_text_x = icon_total_space + pad_x + _text_width(full_label_text, font_size, active_uppercase) / 2
+
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{total_width}" height="{height}" role="img" aria-label="{_esc(label_render)}: {_esc(value_render)}">
 {defs}
 <rect x="0" y="0" width="{left_width}" height="{height}" fill="{_esc(left_fill)}" rx="{radius}" ry="{radius}"{border_attr} />
 <rect x="{left_width}" y="0" width="{right_width}" height="{height}" fill="{_esc(right_fill)}" rx="{radius}" ry="{radius}"{border_attr} />
 <rect x="{max(0, left_width - radius)}" y="0" width="{radius}" height="{height}" fill="{_esc(left_fill)}" />
-<text x="{left_width / 2}" y="{(height / 2) + (font_size * 0.33)}" fill="{_esc(fg_left)}" font-size="{font_size}" font-family="{FONT}" font-weight="{profile.font_weight}" text-anchor="middle">{_esc(label_render)}</text>
+{icon_svg}
+<text x="{label_text_x}" y="{(height / 2) + (font_size * 0.33)}" fill="{_esc(fg_left)}" font-size="{font_size}" font-family="{FONT}" font-weight="{profile.font_weight}" text-anchor="middle">{_esc(label_render)}</text>
 <text x="{left_width + (right_width / 2)}" y="{(height / 2) + (font_size * 0.33)}" fill="{_esc(fg_right)}" font-size="{font_size}" font-family="{FONT}" font-weight="{profile.font_weight}" text-anchor="middle">{_esc(value_render)}</text>
 {overlay}
 </svg>'''
-    return svg

--- a/api/stats_index.py
+++ b/api/stats_index.py
@@ -15,11 +15,16 @@ app = Flask(__name__)
 
 
 def _param(name: str, default: str = "") -> str:
+    if request.method == "POST":
+        return (request.form.get(name) or request.args.get(name, default)).strip()
     return request.args.get(name, default).strip()
 
 
 def _param_bool(name: str, default: bool = False) -> bool:
-    value = request.args.get(name, "").strip().lower()
+    if request.method == "POST":
+        value = (request.form.get(name) or request.args.get(name, "")).strip().lower()
+    else:
+        value = request.args.get(name, "").strip().lower()
     if value in ("1", "true", "yes", "on"):
         return True
     if value in ("0", "false", "no", "off"):
@@ -29,14 +34,16 @@ def _param_bool(name: str, default: bool = False) -> bool:
 
 def _param_int(name: str, default: int, lo: int, hi: int) -> int:
     try:
-        return min(max(int(request.args.get(name, default)), lo), hi)
+        raw = request.form.get(name, request.args.get(name, default)) if request.method == "POST" else request.args.get(name, default)
+        return min(max(int(raw), lo), hi)
     except (TypeError, ValueError):
         return default
 
 
 def _param_float(name: str, default: float, lo: float, hi: float) -> float:
     try:
-        return min(max(float(request.args.get(name, default)), lo), hi)
+        raw = request.form.get(name, request.args.get(name, default)) if request.method == "POST" else request.args.get(name, default)
+        return min(max(float(raw), lo), hi)
     except (TypeError, ValueError):
         return default
 
@@ -59,15 +66,17 @@ def index():
         return Response(file.read(), mimetype="text/html")
 
 
-@app.route("/badge")
+@app.route("/badge", methods=["GET", "POST"])
 def badge():
     preset_name = _param("preset")
     preset = resolve_preset(preset_name)
 
+    icon_data = _param("icon_data") or None
+
     svg = generate_custom_badge(
         label=_param("label", preset["label"]),
         value=_param("value", preset["value"]),
-        icon=_param("icon", preset["icon"]),
+        icon=_param("icon", preset.get("icon", "none")),
         style=_param("style", preset["style"]),
         theme=_param("theme", preset["theme"]),
         label_bg=_param("label_bg") or None,
@@ -81,6 +90,7 @@ def badge():
         compact=_param_bool("compact", False),
         size=_param("size", preset.get("size", "md")),
         scale=_param_float("scale", 1.0, 0.7, 2.0),
+        icon_data=icon_data,
     )
     return _svg_response(svg)
 

--- a/stats_index.html
+++ b/stats_index.html
@@ -46,7 +46,14 @@
         <div><label>Preset</label><select id="preset"></select></div>
         <div><label>Style</label><select id="style"></select></div>
         <div><label>Theme</label><select id="theme"></select></div>
-        <div><label>Icon</label><select id="icon"></select></div>
+        <div>
+          <label>Icon (upload image)</label>
+          <div style="display:flex;gap:8px;align-items:center;">
+            <input id="icon_file" type="file" accept="image/*" style="flex:1;font-size:12px;" />
+            <img id="icon_preview" style="width:24px;height:24px;border-radius:4px;display:none;border:1px solid #314062;" />
+            <button type="button" id="icon_clear" class="alt" style="padding:6px 10px;font-size:11px;display:none;">✕</button>
+          </div>
+        </div>
         <div><label>Label</label><input id="label" value="build" /></div>
         <div><label>Value</label><input id="value" value="passing" /></div>
         <div><label>Size</label><select id="size"></select></div>
@@ -104,8 +111,53 @@
   </div>
 
   <script>
-    const ids = ["preset","style","theme","icon","label","value","size","scale","label_bg","value_bg","label_color","value_color","border_color","border_radius","gradient","uppercase","compact"];
+    const ids = ["preset","style","theme","label","value","size","scale","label_bg","value_bg","label_color","value_color","border_color","border_radius","gradient","uppercase","compact"];
     const input = Object.fromEntries(ids.map(id => [id, document.getElementById(id)]));
+    const iconFileInput = document.getElementById("icon_file");
+    const iconPreview = document.getElementById("icon_preview");
+    const iconClear = document.getElementById("icon_clear");
+    let iconBase64 = "";
+
+    function resizeImage(file, maxSize, callback) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const img = new Image();
+        img.onload = () => {
+          const canvas = document.createElement("canvas");
+          canvas.width = maxSize;
+          canvas.height = maxSize;
+          const ctx = canvas.getContext("2d");
+          const scale = Math.min(maxSize / img.width, maxSize / img.height);
+          const w = img.width * scale;
+          const h = img.height * scale;
+          ctx.drawImage(img, (maxSize - w) / 2, (maxSize - h) / 2, w, h);
+          callback(canvas.toDataURL("image/png"));
+        };
+        img.src = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    }
+
+    iconFileInput.addEventListener("change", () => {
+      const file = iconFileInput.files[0];
+      if (!file) return;
+      resizeImage(file, 64, (dataUrl) => {
+        iconBase64 = dataUrl;
+        iconPreview.src = dataUrl;
+        iconPreview.style.display = "block";
+        iconClear.style.display = "inline-block";
+        render();
+      });
+    });
+
+    iconClear.addEventListener("click", () => {
+      iconBase64 = "";
+      iconFileInput.value = "";
+      iconPreview.style.display = "none";
+      iconClear.style.display = "none";
+      render();
+    });
+
     const pickers = {
       label_bg: document.getElementById("label_bg_picker"),
       value_bg: document.getElementById("value_bg_picker"),
@@ -142,9 +194,21 @@
     const render = () => {
       const query = buildQuery();
       const badgeUrl = `${location.origin}/badge?${query}`;
-      preview.innerHTML = `<img alt="badge preview" src="${badgeUrl}" />`;
-      urlBox.value = badgeUrl;
-      mdBox.value = `![custom badge](${badgeUrl})`;
+      if (iconBase64) {
+        const formData = new URLSearchParams(query);
+        formData.set("icon_data", iconBase64);
+        fetch("/badge", { method: "POST", headers: {"Content-Type": "application/x-www-form-urlencoded"}, body: formData.toString() })
+          .then(r => r.text())
+          .then(svg => {
+            preview.innerHTML = svg;
+            urlBox.value = badgeUrl + " (icon embedded in preview only)";
+            mdBox.value = `<!-- Custom icon badge - use /badge POST with icon_data -->\n![custom badge](${badgeUrl})`;
+          });
+      } else {
+        preview.innerHTML = `<img alt="badge preview" src="${badgeUrl}" />`;
+        urlBox.value = badgeUrl;
+        mdBox.value = `![custom badge](${badgeUrl})`;
+      }
     };
 
     const copyText = async (text) => navigator.clipboard.writeText(text);
@@ -178,7 +242,7 @@
         const appendOptions = (el, values) => values.forEach(v => el.insertAdjacentHTML("beforeend", `<option value="${v}">${v}</option>`));
         appendOptions(input.style, catalog.styles);
         appendOptions(input.theme, catalog.themes);
-        appendOptions(input.icon, catalog.icons);
+        // Icon is now uploaded by user, no dropdown needed
         appendOptions(input.size, catalog.sizes);
         appendOptions(input.preset, Object.keys(catalog.presets));
 
@@ -202,7 +266,7 @@
           if (!p) return;
           input.label.value = p.label;
           input.value.value = p.value;
-          input.icon.value = p.icon;
+          // preset icon ignored - user uploads custom icon
           input.theme.value = p.theme;
           input.style.value = p.style;
           input.size.value = p.size || "md";
@@ -212,7 +276,7 @@
         input.preset.value = "build";
         input.style.value = "flat";
         input.theme.value = "terminal";
-        input.icon.value = "check";
+        // icon is now user-uploaded
         input.size.value = "md";
         colorFields.forEach(syncInputWithPicker);
         render();


### PR DESCRIPTION
- Remove pre-defined icon dropdown, add file upload input with preview
- Uploaded images are resized to 64x64 on client via canvas
- Badge endpoint now accepts POST with icon_data (base64 data URI)
- SVG generator embeds custom icon as <image> element, auto-sized to badge height
- Clear button to remove uploaded icon

https://claude.ai/code/session_01AizX4fbZBKab7Wn1dZ4jFZ

## Description
## Related Issue(s)
Resolves #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Technical Debt

## Testing Performed
- [ ] Local execution of `process_event.py`
- [ ] Verified JSON output structure from Gemini API
- [ ] Tested GitHub Action workflow trigger (dry-run)
- [ ] Other: 

## Checklist
- [ ] My code follows the code style of this project (PEP-8).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (README.md, etc.).
- [ ] My changes generate no new warnings or errors in the CI pipeline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom icon upload functionality – users can now upload and embed custom images as badge icons instead of selecting from a preset catalog.
  * Icon preview display with clear option to replace or remove the uploaded image.

* **Improvements**
  * Badge generation endpoint enhanced to support additional input methods for icon data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->