### PR TITLE
Replace CODE_OF_CONDUCT with Contributor Covenant v2.1

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,118 +2,128 @@
 
 ## Our Pledge
 
-We as members, contributors, and maintainers pledge to make participation in this
-project and community a harassment-free experience for everyone, regardless of
-age, body size, visible or invisible disability, ethnicity, sex characteristics,
-gender identity and expression, level of experience, education,
-socio-economic status, nationality, personal appearance, race, religion, or
-sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-- Demonstrating empathy and kindness
-- Being respectful of differing opinions and experiences
-- Giving and gracefully accepting constructive feedback
-- Taking responsibility, apologizing, and learning from mistakes
-- Prioritizing what is best for the community and project health
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+overall community
 
 Examples of unacceptable behavior include:
 
-- Sexualized language or imagery and any sexual attention or advances
-- Trolling, insulting, derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing private information without explicit permission
-- Any conduct that could reasonably be considered inappropriate in a
-  professional context
+* The use of sexualized language or imagery, and sexual attention or
+advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+professional setting
 
 ## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying and enforcing standards of
-acceptable behavior. They may take fair and appropriate corrective action in
-response to behavior deemed inappropriate, threatening, offensive, or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Maintainers have the right and responsibility to remove, edit, or reject
+Community leaders have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned with this Code of Conduct.
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies in all project spaces, including:
-
-- GitHub Issues
-- Pull Requests
-- Discussions
-- Linked community channels related to this project
-
-It also applies when an individual is officially representing the project in
-public spaces.
+This Code of Conduct applies within all community spaces of
+readme-SVG-custom-badge-generator, and also applies when an individual is
+officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
-If you experience or witness abusive, harassing, or otherwise unacceptable
-behavior, report it using one of these channels:
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+luman160@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
 
-- Open a private moderation request via GitHub (preferred)
-- Contact the maintainer through official profile/community links listed in
-  `README.md`
-
-When reporting, include:
-
-- What happened
-- Where it happened
-- Links/screenshots/logs if available
-
-All complaints will be reviewed promptly and fairly. Privacy and safety of
-reporters will be respected.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
 ## Enforcement Guidelines
 
-Maintainers may apply the following Community Impact Guidelines:
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact:** Inappropriate language or other unprofessional behavior.
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
 
-**Consequence:** A private written warning with clarification on why behavior
-was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact:** A violation through a single incident or repeated actions.
+**Community Impact**: A violation through a single incident or series
+of actions.
 
-**Consequence:** A formal warning with consequences for continued behavior.
-Temporary interaction restrictions may be applied.
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
 
 ### 3. Temporary Ban
 
-**Community Impact:** Serious violation of community standards.
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
 
-**Consequence:** Temporary ban from community interaction for a defined period.
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact:** Pattern of violations, sustained harassment, or
-aggressive/disparaging behavior toward individuals or groups.
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence:** Permanent ban from all project community spaces.
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
 
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0:
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 
-For common questions, see the FAQ:
-https://www.contributor-covenant.org/faq.
-Translations:
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
 https://www.contributor-covenant.org/translations.


### PR DESCRIPTION
### Motivation
- Align the repository with the industry-standard Contributor Covenant (v2.1) to provide a clear, well-known code of conduct and reporting path.

### Description
- Replace the content of `CODE_OF_CONDUCT.md` with the official Contributor Covenant v2.1 text.
- Insert the project name `readme-SVG-custom-badge-generator` into the `Scope` section.
- Set the enforcement/reporting contact to `luman160@gmail.com` in the `Enforcement` section.
- Update the attribution to reference Contributor Covenant version `2.1` and retain the Community Impact Guidelines.

### Testing
- Ran syntax validation with `python -m compileall api scripts` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71746b6f48331902b570f4a4f7f10)