### PR TITLE
Redesign UI to dark Material-inspired workspace

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,11 @@
 
     <!-- ══════════════ CONTROLS PANEL ══════════════ -->
     <aside class="controls-panel" aria-label="Badge controls">
+      <div class="controls-intro">
+        <p class="controls-kicker">Configuration</p>
+        <h1 class="controls-heading">Build your badge</h1>
+        <p class="controls-note">Tune content, style and colors on the left. Copy or download from the workspace on the right.</p>
+      </div>
 
       <!-- Quick Presets -->
       <details class="ctrl-section" open>
@@ -270,6 +275,10 @@
 
     <!-- ══════════════ OUTPUT PANEL ══════════════ -->
     <section class="output-panel" aria-label="Badge preview and output">
+      <div class="workspace-summary">
+        <p class="workspace-kicker">Workspace</p>
+        <h2 class="workspace-title">Preview and export</h2>
+      </div>
 
       <!-- Live Preview -->
       <div class="preview-card">
@@ -325,22 +334,23 @@
         </button>
       </div>
 
-      <!-- Output: Markdown -->
-      <div class="output-group">
-        <div class="output-header">
-          <label class="output-label" for="outputMarkdown">Markdown</label>
-          <button class="output-copy-btn" data-target="outputMarkdown" aria-label="Copy markdown">Copy</button>
+      <!-- Output: Markdown + SVG -->
+      <div class="output-grid">
+        <div class="output-group">
+          <div class="output-header">
+            <label class="output-label" for="outputMarkdown">Markdown</label>
+            <button class="output-copy-btn" data-target="outputMarkdown" aria-label="Copy markdown">Copy</button>
+          </div>
+          <textarea class="output-textarea" id="outputMarkdown" readonly spellcheck="false"></textarea>
         </div>
-        <textarea class="output-textarea" id="outputMarkdown" readonly spellcheck="false"></textarea>
-      </div>
 
-      <!-- Output: SVG Code -->
-      <div class="output-group">
-        <div class="output-header">
-          <label class="output-label" for="outputSvg">SVG Code</label>
-          <button class="output-copy-btn" data-target="outputSvg" aria-label="Copy SVG code">Copy</button>
+        <div class="output-group">
+          <div class="output-header">
+            <label class="output-label" for="outputSvg">SVG Code</label>
+            <button class="output-copy-btn" data-target="outputSvg" aria-label="Copy SVG code">Copy</button>
+          </div>
+          <textarea class="output-textarea output-textarea--tall" id="outputSvg" readonly spellcheck="false"></textarea>
         </div>
-        <textarea class="output-textarea output-textarea--tall" id="outputSvg" readonly spellcheck="false"></textarea>
       </div>
 
       <!-- Style Gallery -->

--- a/styles.css
+++ b/styles.css
@@ -62,17 +62,17 @@
   --md-on-error-container:  #F9DEDC;
 
   /* Surface System */
-  --md-background:          #1C1B1F;
-  --md-on-background:       #E6E1E5;
-  --md-surface:             #1C1B1F;
+  --md-background:          #0B0B0D;
+  --md-on-background:       #E8E8EE;
+  --md-surface:             #121214;
   --md-on-surface:          #E6E1E5;
-  --md-surface-variant:     #49454F;
-  --md-on-surface-variant:  #CAC4D0;
-  --md-surface-lowest:      #0F0D13;
-  --md-surface-low:         #1D1B20;
-  --md-surface-container:   #211F26;
-  --md-surface-high:        #2B2930;
-  --md-surface-highest:     #36343B;
+  --md-surface-variant:     #38363F;
+  --md-on-surface-variant:  #C8C3CF;
+  --md-surface-lowest:      #050507;
+  --md-surface-low:         #15151A;
+  --md-surface-container:   #1A1A20;
+  --md-surface-high:        #23232A;
+  --md-surface-highest:     #2D2D35;
 
   /* Outline */
   --md-outline:             #938F99;
@@ -349,7 +349,7 @@ body {
 /* ─── Main Layout ────────────────────────────────────────────── */
 .app-layout {
   display: grid;
-  grid-template-columns: 360px 1fr;
+  grid-template-columns: minmax(320px, 380px) 1fr;
   flex: 1;
   max-width: 1440px;
   margin: 0 auto;
@@ -370,7 +370,7 @@ body {
   max-height: calc(100dvh - 64px);
   position: sticky;
   top: 64px;
-  padding: 12px 16px 48px;
+  padding: 16px 16px 48px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -392,7 +392,12 @@ body {
   background: var(--md-surface-container);
   border-radius: var(--shape-lg);
   overflow: hidden;
-  transition: box-shadow var(--transition);
+  border: 1px solid color-mix(in srgb, var(--md-outline-variant) 75%, transparent);
+  transition: box-shadow var(--transition), border-color var(--transition);
+}
+
+.ctrl-section:hover {
+  border-color: color-mix(in srgb, var(--md-primary) 24%, var(--md-outline-variant));
 }
 
 /* Collapsible section header */
@@ -940,10 +945,10 @@ details.ctrl-section[open] .ctrl-chevron {
 
 /* ─── Output Panel ───────────────────────────────────────────── */
 .output-panel {
-  padding: 24px 24px 64px;
+  padding: 24px 24px 72px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 18px;
   background: var(--md-background);
 }
 
@@ -956,6 +961,7 @@ details.ctrl-section[open] .ctrl-chevron {
   background: var(--md-surface-container);
   border-radius: var(--shape-xl);
   overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--md-outline-variant) 76%, transparent);
   box-shadow: 0 1px 3px rgba(0,0,0,0.3), 0 4px 8px rgba(0,0,0,0.15);
   transition: box-shadow var(--transition);
 }
@@ -1078,6 +1084,14 @@ details.ctrl-section[open] .ctrl-chevron {
   gap: 10px;
   flex-wrap: wrap;
   align-items: center;
+  background: color-mix(in srgb, var(--md-surface-container) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--md-outline-variant) 76%, transparent);
+  border-radius: var(--shape-xl);
+  padding: 12px;
+  position: sticky;
+  top: 80px;
+  z-index: 40;
+  backdrop-filter: blur(8px);
 }
 
 /* Base button */
@@ -1182,6 +1196,19 @@ details.ctrl-section[open] .ctrl-chevron {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  min-width: 0;
+}
+
+.output-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+@media (max-width: 1140px) {
+  .output-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .output-header {
@@ -1253,7 +1280,10 @@ details.ctrl-section[open] .ctrl-chevron {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  padding-top: 4px;
+  padding: 10px 14px 14px;
+  border: 1px solid color-mix(in srgb, var(--md-outline-variant) 78%, transparent);
+  border-radius: var(--shape-xl);
+  background: var(--md-surface-low);
 }
 
 .gallery-title {
@@ -1331,6 +1361,56 @@ details.ctrl-section[open] .ctrl-chevron {
   letter-spacing: 0.02em;
   color: var(--md-outline);
   background: var(--md-surface-low);
+}
+
+.controls-intro {
+  padding: 4px 6px 12px;
+}
+
+.controls-kicker,
+.workspace-kicker {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--md-primary);
+  font-weight: 500;
+}
+
+.controls-heading {
+  font-size: 24px;
+  line-height: 1.2;
+  margin: 4px 0 8px;
+  font-weight: 500;
+}
+
+.controls-note {
+  color: var(--md-on-surface-variant);
+  line-height: 1.45;
+  font-size: 13px;
+}
+
+.workspace-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.workspace-title {
+  font-size: 24px;
+  line-height: 1.2;
+  font-weight: 500;
+}
+
+@media (max-width: 960px) {
+  .controls-heading,
+  .workspace-title {
+    font-size: 20px;
+  }
+
+  .action-bar {
+    position: static;
+    backdrop-filter: none;
+  }
 }
 
 /* ─── Scrollbar ──────────────────────────────────────────────── */


### PR DESCRIPTION
### Motivation
- Improve usability and visual hierarchy so users can find controls, preview, and export faster.  
- Adopt a Google Material-like dark theme (black/charcoal surfaces, elevated cards) to increase contrast and focus.  

### Description
- Added a short controls intro and prominent workspace header to the layout in `index.html` to clarify intent and reduce cognitive load.  
- Reworked the output area into an `output-grid` with responsive two-column layout for Markdown and SVG blocks to reduce vertical scrolling.  
- Tuned the dark color tokens and surface palette in `styles.css` to deeper black/charcoal values while keeping MD tokens and state layers.  
- Improved panel ergonomics and spacing: constrained controls column width, stronger card borders, sticky desktop `action-bar`, gallery card background and padding adjustments (changes in `index.html` and `styles.css`).  

### Testing
- Ran a quick static check: `git diff --check` (no issues). — succeeded.  
- Validated Python modules used elsewhere with `python3 -m py_compile process_event.py ai_issue_generator.py api/*.py` — succeeded.  
- Served the app locally with `python3 -m http.server 4173` and visually inspected the redesigned UI in a browser; captured a full-page screenshot for verification (local manual check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71ef83704833184cca2eb20b1e3f4)