### PR TITLE
Make control sections single-open and unify output textarea heights

### DIFF
--- a/app.js
+++ b/app.js
@@ -765,6 +765,20 @@ function initFormWiring() {
   }
 }
 
+function initControlSections() {
+  const sections = Array.from(document.querySelectorAll('.ctrl-section'));
+
+  sections.forEach(section => {
+    section.open = false;
+    section.addEventListener('toggle', () => {
+      if (!section.open) return;
+      sections.forEach(other => {
+        if (other !== section) other.open = false;
+      });
+    });
+  });
+}
+
 /* ═══════════════════════════════════════════════════════════════
    ACTION BUTTONS
    ═══════════════════════════════════════════════════════════════ */
@@ -842,6 +856,7 @@ function initThemeToggle() {
 
 function init() {
   initThemeToggle();
+  initControlSections();
   initPresets();
   initFormWiring();
   initColorSync();

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
       </div>
 
       <!-- Quick Presets -->
-      <details class="ctrl-section" open>
+      <details class="ctrl-section">
         <summary class="ctrl-section-header">
           <span class="ctrl-section-icon" aria-hidden="true">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
@@ -76,7 +76,7 @@
       </details>
 
       <!-- Content -->
-      <details class="ctrl-section" open>
+      <details class="ctrl-section">
         <summary class="ctrl-section-header">
           <span class="ctrl-section-icon" aria-hidden="true">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
@@ -103,7 +103,7 @@
       </details>
 
       <!-- Appearance -->
-      <details class="ctrl-section" open>
+      <details class="ctrl-section">
         <summary class="ctrl-section-header">
           <span class="ctrl-section-icon" aria-hidden="true">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
@@ -141,7 +141,7 @@
       </details>
 
       <!-- Colors -->
-      <details class="ctrl-section" open>
+      <details class="ctrl-section">
         <summary class="ctrl-section-header">
           <span class="ctrl-section-icon" aria-hidden="true">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
@@ -349,7 +349,7 @@
             <label class="output-label" for="outputSvg">SVG Code</label>
             <button class="output-copy-btn" data-target="outputSvg" aria-label="Copy SVG code">Copy</button>
           </div>
-          <textarea class="output-textarea output-textarea--tall" id="outputSvg" readonly spellcheck="false"></textarea>
+          <textarea class="output-textarea" id="outputSvg" readonly spellcheck="false"></textarea>
         </div>
       </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1273,7 +1273,6 @@ details.ctrl-section[open] .ctrl-chevron {
 
 .output-textarea:hover  { border-color: var(--md-outline); }
 .output-textarea:focus  { border-color: var(--md-primary); border-width: 2px; }
-.output-textarea--tall  { min-height: 120px; }
 
 /* ─── Gallery (MD3 Cards) ────────────────────────────────────── */
 .gallery-section {


### PR DESCRIPTION
### Motivation

- Improve the left-side controls UX so all sections start collapsed and only one section can be expanded at a time (accordion behavior).
- Ensure the `Markdown` and `SVG Code` output areas render at the same height for a more consistent workspace.

### Description

- Removed the `open` attribute from the left-side `<details class="ctrl-section">` blocks in `index.html` so sections start closed by default.
- Added `initControlSections()` in `app.js` which collapses all sections initially and enforces that when a section is opened any other open section is closed, and wired it into `init()`.
- Unified output textarea sizing by removing the `output-textarea--tall` usage from `index.html` and deleting the corresponding CSS rule in `styles.css`, so both `Markdown` and `SVG Code` use the same base `.output-textarea` dimensions.
- Key files changed: `index.html`, `app.js`, `styles.css`.

### Testing

- Ran `node --check app.js` with no errors, confirming the JavaScript is syntactically valid.
- Ran `python -m py_compile process_event.py ai_issue_generator.py api/data_fetchers.py api/github_stats.py` with no errors to ensure Python modules remain valid.
- Launched a local HTTP server and executed a Playwright check which verified that all control sections are closed initially, opening one section yields exactly one open section, and opening a second collapses the previous one (Playwright output showed one open section after interactions), and a screenshot of the updated UI was captured successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72e98fc6483319a5b890b20a2ee4c)